### PR TITLE
Serialize and pretty-print graph.

### DIFF
--- a/java-parse/src/java/GraphDebug.ml
+++ b/java-parse/src/java/GraphDebug.ml
@@ -58,13 +58,28 @@ module ImplicationDot = struct
 
   let formula_to_str (edge: ImplicationGraph.Edge.t) =
     let open ImplicationGraph.Edge in
-    let formula = Ir.sexp_of_expr edge.formula |> Sexp.to_string in
-    let rename = edge.rename
-                 |> List.map ~f:(fun (a, b) -> Printf.sprintf "%s &rarr; %s" a b)
-                 |> String.concat ~sep:", "
+    let formula =
+      Ir.pprint_expr false edge.formula
+      |> String.substr_replace_all ~pattern:"!=" ~with_:"&ne;"
+      |> String.substr_replace_all ~pattern:"<=" ~with_:"&le;"
+      |> String.substr_replace_all ~pattern:">=" ~with_:"&ge;"
+      |> String.substr_replace_all ~pattern:"*" ~with_:"&sdot;"
+      |> String.substr_replace_all ~pattern:"-" ~with_:"&minus;"
+      |> String.substr_replace_all ~pattern:"->" ~with_:"&rarr;"
+      |> String.substr_replace_all ~pattern:"<->" ~with_:"&harr;"
+      |> String.substr_replace_all ~pattern:"||" ~with_:"&or;"
+      |> String.substr_replace_all ~pattern:"&&" ~with_:"&and;"
     in
-    Printf.sprintf "%s\n{%s}"
-                   formula rename
+    if List.hd edge.rename |> Option.is_some
+    then
+      let rename =
+        edge.rename
+        |> List.map ~f:(fun (a, b) -> Printf.sprintf "%s &rarr; %s" a b)
+        |> String.concat ~sep:", "
+      in
+      Printf.sprintf "%s\n{%s}" formula rename
+    else
+      Printf.sprintf "%s" formula
 
   let edge_attributes e = [
       `Label (E.label e |> formula_to_str);

--- a/java-parse/src/java/Ir.ml
+++ b/java-parse/src/java/Ir.ml
@@ -76,3 +76,50 @@ type command = Seq of command * command
              | Skip
 [@@deriving hash, compare, sexp]
 
+
+let rec pprint_kind = function
+  | Unit -> "V"
+  | Bool -> "B"
+  | Int -> "I"
+  | Real -> "F"
+  | List k -> Printf.sprintf "[%s]" (pprint_kind k)
+
+let pprint_var = function
+  | Bound (i, k) -> Printf.sprintf "(%d):%s" i (pprint_kind k)
+  | Free (n, k) -> Printf.sprintf "%s:%s" n (pprint_kind k)
+
+let rec pprint_binop op a b parens =
+  if parens
+  then Printf.sprintf "(%s %s %s)" (pprint_expr true a) op (pprint_expr true b)
+  else Printf.sprintf "%s %s %s" (pprint_expr true a) op (pprint_expr true b)
+
+and pprint_expr parens = function
+  (* Binops *)
+  | ExprCons (ExprCons (Distinct _, a), b) -> pprint_binop "!=" a b parens
+  | ExprCons (ExprCons (Eql _, a), b) -> pprint_binop "=" a b parens
+  | ExprCons (ExprCons (Lt _, a), b) -> pprint_binop "<" a b parens
+  | ExprCons (ExprCons (Le _, a), b) -> pprint_binop "<=" a b parens
+  | ExprCons (ExprCons (Gt  _, a), b) -> pprint_binop ">" a b parens
+  | ExprCons (ExprCons (Ge _, a), b) -> pprint_binop ">=" a b parens
+  | ExprCons (ExprCons (Add _, a), b) -> pprint_binop "+" a b parens
+  | ExprCons (ExprCons (Mul _, a), b) -> pprint_binop "*" a b parens
+  | ExprCons (ExprCons (Sub _, a), b) -> pprint_binop "-" a b parens
+  | ExprCons (ExprCons (Div _, a), b) -> pprint_binop "/" a b parens
+  | ExprCons (ExprCons (Mod _, a), b) -> pprint_binop "%" a b parens
+  | ExprCons (ExprCons (Impl, a), b) -> pprint_binop "->" a b parens
+  | ExprCons (ExprCons (Iff, a), b) -> pprint_binop "<->" a b parens
+  | ExprCons (ExprCons (And, a), b) -> pprint_binop "&&" a b parens
+  | ExprCons (ExprCons (Or, a), b) -> pprint_binop "||" a b parens
+
+  (* Uniops *)
+  | ExprCons (Not, a) -> Printf.sprintf "!%s" (pprint_expr true a)
+
+  (* Literals *)
+  | LUnit -> "()"
+  | LBool b -> Printf.sprintf "%B" b
+  | LInt i -> Printf.sprintf "%d" i
+  | LReal f -> Printf.sprintf "%f" f
+  | Var v -> pprint_var v
+
+  | other -> sexp_of_expr other |> Sexp.to_string
+


### PR DESCRIPTION
Now we got nice prints of the implication graph:

<p align="center">
<img src="https://user-images.githubusercontent.com/4401220/32066376-908a18b8-ba4d-11e7-9e82-fc6a7f45eac8.png">
</p>

And we have a good JSON representation:

```JSON
{
  "edges": [
    {
      "start": "EvenLoop/loop/2",
      "end": "EvenLoop/loop/1",
      "formula": "(ExprCons(ExprCons(Eql Int)(Var(Free i' Int)))(ExprCons(ExprCons(Add Int)(Var(Free i Int)))(LInt 2)))",
      "rename": [
        {
          "i": "i'"
        }
      ]
    },
    {
      "start": "EvenLoop/loop/1",
      "end": "EvenLoop/loop/4",
      "formula": "(ExprCons(ExprCons(Ge Int)(Var(Free i Int)))(Var(Free n Int)))",
      "rename": []
    },
    {
      "start": "EvenLoop/loop/1",
      "end": "EvenLoop/loop/2",
      "formula": "(ExprCons Not(ExprCons(ExprCons(Ge Int)(Var(Free i Int)))(Var(Free n Int))))",
      "rename": []
    },
    {
      "start": "EvenLoop/loop/0",
      "end": "EvenLoop/loop/1",
      "formula": "(ExprCons(ExprCons(Eql Int)(Var(Free i Int)))(LInt 0))",
      "rename": []
    }
  ],
  "vertices": {
    "EvenLoop/loop/4": [
      "i"
    ],
    "EvenLoop/loop/2": [
      "i",
      "n"
    ],
    "EvenLoop/loop/1": [
      "i",
      "n"
    ],
    "EvenLoop/loop/0": [
      "n"
    ]
  }
}
```