### PR TITLE
Correctly detect and translate booleans.

### DIFF
--- a/java-parse/examples/squashing/Squash.java
+++ b/java-parse/examples/squashing/Squash.java
@@ -1,0 +1,33 @@
+public class Squash {
+
+    public int canSquash(boolean p, boolean q) {
+        int x = 0, y = 0, z = 0;
+        if (p && q) {
+            x = 3;
+            y = 7;
+        } else {
+            x = 4;
+            if (q) {
+                z = 1;
+            } else {
+                z = 7;
+            }
+        }
+        return x + y + z;
+    }
+
+
+    public int cannotSquash(boolean p) {
+        int x = 0, y = 0;
+        if (p) {
+            x = 3;
+            y = 7;
+        } else {
+            x = 4;
+            while (x < 40) {
+                x = x + 1;
+            }
+        }
+        return x + y;
+    }
+}


### PR DESCRIPTION
We now have real bool values. This is an example:

```java
    public int canSquash(boolean p, boolean q) {
        int x = 0, y = 0, z = 0;
        if (p && q) {
            x = 3;
            y = 7;
        } else {
            x = 4;
            if (q) {
                z = 1;
            } else {
                z = 7;
            }
        }
        return x + y + z;
    }
```

![squash-cansquash dot](https://user-images.githubusercontent.com/4401220/32138022-5cdd1de6-bbf9-11e7-997a-4ac54f7284e9.png)

Fixes #8 .