### PR TITLE
Quering support in Java.

### DIFF
--- a/Logic.cabal
+++ b/Logic.cabal
@@ -25,7 +25,7 @@ library
                      , Logic.ImplicationGraph.Equivalence
                      , Logic.ImplicationGraph.Safety
                      , Logic.ImplicationGraph.Simplify
-                      , Logic.ImplicationGraph.JSONParser
+                     , Logic.ImplicationGraph.JSONParser
                      , Logic.Solver.Z3
                      , Data.Optic.Graph.Extras
 

--- a/app/ImplicationGraphExample.hs
+++ b/app/ImplicationGraphExample.hs
@@ -20,7 +20,7 @@ import qualified Data.ByteString.Lazy.Char8 as BS
 main :: IO ()
 main = do
   G.display "before.dot" example
-  sol <- solve 2 example
+  sol <- solve example
   case sol of
     Left m -> print (pretty m)
     Right r -> do

--- a/app/SimplifyExample.hs
+++ b/app/SimplifyExample.hs
@@ -29,11 +29,12 @@ main = let
         print $ pretty $ _edgeForm dj
 
         parsedGraph <- parseGraphFromJSON <$> BS.readFile "test.json"
-        -- putStrLn "Trying to simplify JSON..."
-        -- G.display "before.dot" parsedGraph
-        -- G.display "simplified.dot" $ S.prune parsedGraph
+        let pruned = S.prune parsedGraph
+        putStrLn "Trying to simplify JSON..."
+        G.display "before.dot" parsedGraph
+        G.display "simplified.dot" pruned
 
-        sol <- solve parsedGraph
+        sol <- solve pruned
         case sol of
           Left m -> do
             putStrLn "Could not prove safety:"

--- a/app/SimplifyExample.hs
+++ b/app/SimplifyExample.hs
@@ -8,6 +8,7 @@ import           Data.Text.Prettyprint.Doc
 import qualified Data.ByteString.Lazy.Char8 as BS
 
 import           Logic.ImplicationGraph
+import           Logic.ImplicationGraph.Safety
 import           Logic.ImplicationGraph.Simplify as S
 import           Logic.ImplicationGraph.JSONParser (parseGraphFromJSON)
 import qualified Logic.Type as T
@@ -28,9 +29,19 @@ main = let
         print $ pretty $ _edgeForm dj
 
         parsedGraph <- parseGraphFromJSON <$> BS.readFile "test.json"
-        putStrLn "Trying to simplify JSON:"
-        G.display "before.dot" parsedGraph
-        G.display "simplified.dot" $ S.prune parsedGraph
+        -- putStrLn "Trying to simplify JSON..."
+        -- G.display "before.dot" parsedGraph
+        -- G.display "simplified.dot" $ S.prune parsedGraph
+
+        sol <- solve parsedGraph
+        case sol of
+          Left m -> do
+            putStrLn "Could not prove safety:"
+            print (pretty m)
+          Right r -> do
+            putStrLn "Safe!"
+            G.display "solved.dot" r
+            print . pretty . M.toList =<< collectAnswer r
 
 i :: Var
 i  = Free ["i"] 0 T.Int
@@ -67,17 +78,17 @@ disjunctionExample =
 
         e1 = Edge {
             _edgeMap = M.fromList [(i, i')],
-            _edgeForm = foldl1 mkAnd $ 
-                [(Eql T.Int :@ V i :@ LInt 0)
-                , (Eql T.Int :@ V i' :@ V i)]
+            _edgeForm = foldl1 mkAnd
+                        [ Eql T.Int :@ V i :@ LInt 0
+                        , Eql T.Int :@ V i' :@ V i]
         }
 
         e2 = Edge {
             _edgeMap = M.fromList [(i, i'')],
-            _edgeForm = foldl1 mkAnd $ 
-                [(Eql T.Int :@ V i :@ LInt 0)
-                , (Eql T.Int :@ V i' :@ V i)
-                , (Eql T.Int :@ V i'' :@ V i')]
+            _edgeForm = foldl1 mkAnd
+                        [Eql T.Int :@ V i :@ LInt 0
+                        , Eql T.Int :@ V i' :@ V i
+                        , Eql T.Int :@ V i'' :@ V i']
         }
     in
         (e1, e2)

--- a/java-parse/Wunderhorn.java
+++ b/java-parse/Wunderhorn.java
@@ -1,0 +1,8 @@
+public class Wunderhorn {
+  public static int arby_int() { return 0; }
+  public static boolean arby_bool() { return true; }
+  public static double arby_double() { return 0; }
+  public static float arby_float() { return 0; }
+  public static void ensure(boolean b) {}
+  public static void assume(boolean b) {}
+}

--- a/java-parse/_oasis
+++ b/java-parse/_oasis
@@ -19,7 +19,7 @@ Library java
   BuildDepends: core, sawja, ocamlgraph, util, ppx_hash, ppx_compare, ppx_sexp_conv, ppx_deriving
   ByteOpt:      -thread
   NativeOpt:    -thread
-  Modules:      ParseJava, InstrGraph, GraphDebug, Ir, ImplicationGraph
+  Modules:      ParseJava, InstrGraph, GraphDebug, Ir, ImplicationGraph, BuiltIn
 
 Executable equivalencecheck
   Path:         src

--- a/java-parse/examples/simple/EvenLoop.java
+++ b/java-parse/examples/simple/EvenLoop.java
@@ -1,10 +1,9 @@
 public class EvenLoop {
-
-    public static int loop(int n) {
+    public static void loop(int n) {
         int i = 0;
         while (i < n) {
             i = i + 2;
         }
-        return i;
+        Wunderhorn.ensure(i % 2 == 0);
     }
 }

--- a/java-parse/examples/simple/EvenLoop.java
+++ b/java-parse/examples/simple/EvenLoop.java
@@ -4,6 +4,6 @@ public class EvenLoop {
         while (i < n) {
             i = i + 2;
         }
-        Wunderhorn.ensure(i % 2 == 0);
+        Wunderhorn.ensure(i != 41);
     }
 }

--- a/java-parse/src/java/BuiltIn.ml
+++ b/java-parse/src/java/BuiltIn.ml
@@ -1,0 +1,68 @@
+module JBasics = Javalib_pack.JBasics
+
+open Core
+
+let is_built_in_class cn =
+  let name = JBasics.cn_name cn in
+     name = "java.util.Scanner"
+  || name = "java.util.Properties"
+  || name = "java.util.Arrays"
+  || name = "java.util.ArrayList$SubList"
+  || name = "java.util.Collections$UnmodifiableList"
+  || name = "java.io.BufferedInputStream"
+  || name = "java.lang.Boolean"
+  || name = "java.lang.Integer"
+  || name = "java.lang.Long"
+  || name = "java.lang.System"
+  || name = "java.lang.Object"
+  || name = "java.lang.Class"
+  || name = "java.lang.Math"
+  || name = "java.lang.Throwable"
+  || name = "sun.misc.VM"
+  || String.is_substring name ~substring:"String"
+  || String.is_substring name ~substring:"Error"
+  || String.is_substring name ~substring:"Exception"
+
+let built_in_list =
+  [ "hasNextShort"
+  ; "hasNextInt"
+  ; "hasNextLong"
+  ; "hasNextBigInteger"
+  ; "hasNextFloat"
+  ; "hasNextDouble"
+  ; "hasNextBoolean"
+  ; "nextBoolean"
+  ; "nextShort"
+  ; "nextInt"
+  ; "nextLong"
+  ; "nextBigInteger"
+  ; "nextFloat"
+  ; "nextDouble"
+  ; "print"
+  ; "println"
+  ; "close"
+  ; "flush"
+  ; "getClass"
+  ; "getComponentType"
+  ; "desiredAssertionStatus"
+  ; "getPrimitiveClass"
+  ; "getSavedProperty"
+  ; "outOfBoundsMsg"
+  ; "floatToRawIntBits"
+  ; "doubleToRawLongBits"
+  ; "toString"
+  ; "stringSize"
+  ; "getChars"
+  ; "checkForComodification"
+  ; "newArray"
+  ; "hugeCapacity"
+  ; "copyOf"
+  ]
+
+let call_built_in_method cn ms v args =
+  let mname = JBasics.ms_name ms in
+  let cname = JBasics.cn_name cn in
+
+  match (cname, mname, args) with
+  | ("Wunderhorn", "ensure", [(q, _)]) -> Some (q, Ir.Query)
+  | _ -> Printf.sprintf "Method %s.%s not supported." cname mname |> failwith

--- a/java-parse/src/java/BuiltIn.ml
+++ b/java-parse/src/java/BuiltIn.ml
@@ -64,5 +64,5 @@ let call_built_in_method cn ms v args =
   let cname = JBasics.cn_name cn in
 
   match (cname, mname, args) with
-  | ("Wunderhorn", "ensure", [(q, _)]) -> Some (q, Ir.Query)
+  | ("Wunderhorn", "ensure", [(q, _)]) -> Some (Ir.LBool true, Ir.Query q)
   | _ -> Printf.sprintf "Method %s.%s not supported." cname mname |> failwith

--- a/java-parse/src/java/ImplicationGraph.ml
+++ b/java-parse/src/java/ImplicationGraph.ml
@@ -18,6 +18,7 @@ module Vertex = struct
   type t = {
       loc: QualifiedIdentity.t;
       live: Ir.var list;
+      kind: Ir.vkind;
     }
   [@@deriving hash, compare]
 
@@ -36,24 +37,28 @@ let to_implication
         (graph: t) =
     let open Vertex in
     let open Edge in
-    let get_var var = InstrGraph.java_to_var vartable v.InstrGraph.Instr.loc None var |> fst in
+    let instr = v.InstrGraph.Instr.instr in
+    let loc = v.InstrGraph.Instr.loc in
+    let (expr, rename, k) = match (InstrGraph.instr_to_expr vartable loc instr, e) with
+      | (Some (expr, r, k), InstrGraph.Branch.True) -> (expr, r, k)
+      | (Some (expr, r, k), InstrGraph.Branch.Goto) -> (expr, r, k)
+      | (Some (expr, r, k), InstrGraph.Branch.False) -> (Ir.ExprCons (Ir.Not, expr), r, k)
+      | (None, _) -> (Ir.LBool true, [], Ir.Instance)
+    in
+    let get_var var = InstrGraph.java_to_var vartable v.InstrGraph.Instr.loc None var
+                      |> fst
+    in
     let live_names env = env |> Env.elements |> List.map ~f:get_var in
     let start = {
         loc = v.InstrGraph.Instr.loc;
         live = live_names v.InstrGraph.Instr.live;
+        kind = Ir.Instance;
       } in
     let finish = {
         loc = v'.InstrGraph.Instr.loc;
         live = live_names v'.InstrGraph.Instr.live;
+        kind = k;
       } in
-    let instr = v.InstrGraph.Instr.instr in
-    let loc = v.InstrGraph.Instr.loc in
-    let (expr, rename) = match (InstrGraph.instr_to_expr vartable loc instr, e) with
-      | (Some (expr, r), InstrGraph.Branch.True) -> (expr, r)
-      | (Some (expr, r), InstrGraph.Branch.Goto) -> (expr, r)
-      | (Some (expr, r), InstrGraph.Branch.False) -> (Ir.ExprCons (Ir.Not, expr), r)
-      | (None, _) -> (Ir.LBool true, [])
-    in
     let edge = {
         formula = expr;
         rename = rename;
@@ -70,7 +75,11 @@ let serialize (graph: t) =
                 |> List.map ~f:Ir.jsonsexp_var
                 |> String.concat ~sep:","
     in
-    (Printf.sprintf "\"%s\":[%s]" (QID.as_path v.loc) lives) :: l
+    (Printf.sprintf "\"%s\":{\"type\":\"%s\",\"live\":[%s]}"
+       (QID.as_path v.loc)
+       (Ir.string_of_vkind v.kind)
+       lives
+    ) :: l
   in
   let vertices = fold_vertex collect_vertices graph [] in
   let vlist = String.concat vertices ~sep:"," |> Printf.sprintf "{%s}" in

--- a/java-parse/src/java/ImplicationGraph.ml
+++ b/java-parse/src/java/ImplicationGraph.ml
@@ -75,10 +75,16 @@ let serialize (graph: t) =
                 |> List.map ~f:Ir.jsonsexp_var
                 |> String.concat ~sep:","
     in
-    (Printf.sprintf "\"%s\":{\"type\":\"%s\",\"live\":[%s]}"
-       (QID.as_path v.loc)
-       (Ir.string_of_vkind v.kind)
-       lives
+    (match v.kind with
+     | Ir.Instance -> Printf.sprintf "\"%s\":{\"type\":\"%s\",\"live\":[%s]}"
+                        (QID.as_path v.loc)
+                        (Ir.string_of_vkind v.kind)
+                        lives
+     | Ir.Query ex -> Printf.sprintf "\"%s\":{\"type\":\"%s\",\"query\":%s,\"live\":[%s]}"
+                        (QID.as_path v.loc)
+                        (Ir.string_of_vkind v.kind)
+                        (Ir.jsonsexp_expr ex)
+                        lives
     ) :: l
   in
   let vertices = fold_vertex collect_vertices graph [] in

--- a/java-parse/src/java/InstrGraph.ml
+++ b/java-parse/src/java/InstrGraph.ml
@@ -303,6 +303,11 @@ let instr_to_expr vartable loc = function
      let (irvar, t_a) = java_to_var vartable loc None var in
      let (irexpr, t_b) = java_to_expr vartable loc expr in
      let kind = resolve_types (t_a, t_b) in
+     let irexpr = match (kind, irexpr) with
+       | (Ir.Bool, Ir.LInt 0) -> Ir.LBool false
+       | (Ir.Bool, Ir.LInt 1) -> Ir.LBool true
+       | (_, e) -> e
+     in
      let irvar' = rename_var (fun v -> QID.specify (QID.unspecify v) "1") irvar in
      let expr = (Ir.Eql kind) $:: (Ir.Var irvar') $:: irexpr in
      Some (expr, [(irvar, irvar')], Ir.Instance)

--- a/java-parse/src/java/Ir.ml
+++ b/java-parse/src/java/Ir.ml
@@ -6,11 +6,6 @@ type name = string
 [@@deriving hash, compare, sexp]
 
 
-type vkind = Query
-           | Instance
-[@@deriving hash, compare, sexp]
-
-
 type kind = Unit
           | Bool
           | Int
@@ -63,6 +58,11 @@ type expr = Var of var
 [@@deriving hash, compare, sexp]
 
 
+type vkind = Query of expr
+           | Instance
+[@@deriving hash, compare, sexp]
+
+
 (* -- | The right hand side of an assignment. *)
 type rhs = Expr of expr
          | Arbitrary of kind
@@ -83,7 +83,7 @@ type command = Seq of command * command
 [@@deriving hash, compare, sexp]
 
 let string_of_vkind = function
-  | Query -> "query"
+  | Query _ -> "query"
   | Instance -> "instance"
 
 let rec pprint_kind = function

--- a/java-parse/src/java/Ir.ml
+++ b/java-parse/src/java/Ir.ml
@@ -6,6 +6,11 @@ type name = string
 [@@deriving hash, compare, sexp]
 
 
+type vkind = Query
+           | Instance
+[@@deriving hash, compare, sexp]
+
+
 type kind = Unit
           | Bool
           | Int
@@ -77,6 +82,9 @@ type command = Seq of command * command
              | Skip
 [@@deriving hash, compare, sexp]
 
+let string_of_vkind = function
+  | Query -> "query"
+  | Instance -> "instance"
 
 let rec pprint_kind = function
   | Unit -> "V"

--- a/java-parse/src/main.ml
+++ b/java-parse/src/main.ml
@@ -69,6 +69,7 @@ let print_implication files methods output () =
   collect_files_methods 1 files methods
   |> List.map ~f:parse
   |> List.map ~f:(fun (p, m, v) -> (InstrGraph.build_graph p m, m, v))
+  |> List.map ~f:(fun (g, m, v) -> (g, m, InstrGraph.infer_bools v g))
   |> List.map ~f:(fun (g, m, v) -> (ImplicationGraph.to_implication g v, m))
   |> List.iter ~f:serialize
 

--- a/src/Logic/ImplicationGraph.hs
+++ b/src/Logic/ImplicationGraph.hs
@@ -52,8 +52,11 @@ data Idx = Idx { _idxIden :: Integer, _idxInst :: Integer }
   deriving (Show, Read, Eq, Data)
 makeLenses ''Idx
 
-firstInst :: Integer -> Idx
-firstInst i = Idx i 0
+class (Eq a, Ord a) => IntoIdx a where
+  intoIdx :: a -> Idx
+
+instance IntoIdx Integer where
+  intoIdx i = Idx i 0
 
 match :: Idx -> Idx -> Bool
 match x y = x ^. idxIden == y ^. idxIden

--- a/src/Logic/ImplicationGraph/Equivalence.hs
+++ b/src/Logic/ImplicationGraph/Equivalence.hs
@@ -36,7 +36,7 @@ solve :: MonadIO m
       -> ImplGr Integer
       -> ImplGr Integer
       -> m (Either Model (ProdGr Idx))
-solve e1 e2 quer g1 g2 = G.display "before" wQuery >> loop equivStrat end wQuery
+solve e1 e2 quer g1 g2 = G.display "before" wQuery >> loop equivStrat wQuery
   where
     wQuery =
       equivProduct g1 g2

--- a/src/Logic/ImplicationGraph/Induction.hs
+++ b/src/Logic/ImplicationGraph/Induction.hs
@@ -11,8 +11,7 @@ import qualified Data.Optic.Graph as G
 import qualified Data.Optic.Graph.Extras as G
 import           Data.Map (Map)
 import qualified Data.Map as M
-import           Data.Maybe (mapMaybe, isJust, fromMaybe)
-import           Data.List (find)
+import           Data.Maybe (mapMaybe, fromMaybe)
 
 import           Logic.Formula
 import           Logic.Model
@@ -66,14 +65,6 @@ descendantInstanceVs g i =
     & filter (match i)
     & filter (/= i)
     & mapMaybe (\i' -> g ^? ix i' . _InstanceV . _2)
-
--- | Find the first query node of a graph
-findQuery :: Graph i e Vert -> Maybe i
-findQuery = fmap fst . find (isJust . preview _QueryV . view _2) . M.assocs . G._vertMap
-
--- | Find the entry node (one without edges going into it)
-findEntry :: Ord i => Graph i e v -> i
-findEntry = minimum . G.idxs
 
 -- | Apply the strategy to the graph until a either a counterxample or an inductive
 -- solution is found.

--- a/src/Logic/ImplicationGraph/Induction.hs
+++ b/src/Logic/ImplicationGraph/Induction.hs
@@ -68,16 +68,16 @@ descendantInstanceVs g i =
 
 -- | Apply the strategy to the graph until a either a counterxample or an inductive
 -- solution is found.
-loop :: MonadIO m
+loop :: (IntoIdx i, MonadIO m)
      => Strategy e
-     -> Integer -> Graph Integer e Vert -> m (Either Model (Graph Idx e Vert))
+     -> i -> Graph i e Vert -> m (Either Model (Graph Idx e Vert))
 loop strat end g =
-  runSolve (loop' (G.mapIdxs firstInst g)) >>= \case
+  runSolve (loop' (G.mapIdxs intoIdx g)) >>= \case
     Left (Failed m) -> return (Left m)
     Left (Complete res) -> return (Right res)
     Right _ -> error "infinite loop terminated successfully?"
   where
-    loop' gr = loop' =<< step strat (firstInst end) gr
+    loop' gr = loop' =<< step strat (intoIdx end) gr
 
 -- | Perform a step of the unwinding by
 -- 1. interpolating over the current graph

--- a/src/Logic/ImplicationGraph/JSONParser.hs
+++ b/src/Logic/ImplicationGraph/JSONParser.hs
@@ -103,7 +103,7 @@ instance FromJSON JSONVertex where
       (String t) | t == "instance" ->
                    return $ JVertex $ InstanceV live (LBool False)
       (String t) | t == "query" ->
-                   return $ JVertex $ QueryV (LBool False)
+                   (JVertex . QueryV) <$> (o .: "query" >>= parseJSON)
       _ -> mzero
   parseJSON _ = mzero
 

--- a/src/Logic/ImplicationGraph/JSONParser.hs
+++ b/src/Logic/ImplicationGraph/JSONParser.hs
@@ -75,6 +75,9 @@ instance Ord Line where
 instance Show Line where
   show (LineNo path num) = L.intercalate "/" $ path ++ [show num]
 
+instance IntoIdx Line where
+  intoIdx (LineNo _ n) = Idx (toInteger n) 0
+
 instance Pretty Line where
   pretty = pretty . show
 

--- a/src/Logic/ImplicationGraph/Safety.hs
+++ b/src/Logic/ImplicationGraph/Safety.hs
@@ -10,7 +10,7 @@ import           Logic.ImplicationGraph.Induction
 
 -- | Repeatedly unwind the program until a counterexample is found or inductive
 -- invariants are found.
-solve :: (IntoIdx i, MonadIO m) => i -> ImplGr i -> m (Either Model (ImplGr Idx))
+solve :: (IntoIdx i, MonadIO m) => ImplGr i -> m (Either Model (ImplGr Idx))
 solve = loop safetyStrat
 
 safetyStrat :: Strategy Edge

--- a/src/Logic/ImplicationGraph/Safety.hs
+++ b/src/Logic/ImplicationGraph/Safety.hs
@@ -1,12 +1,8 @@
 module Logic.ImplicationGraph.Safety where
 
 import           Control.Monad.State
-import           Control.Monad.Except
 
 import qualified Data.Optic.Graph as G
-import qualified Data.Optic.Graph.Extras as G
-import qualified Data.Map as M
-import           Data.Map (Map)
 
 import           Logic.Model
 import           Logic.ImplicationGraph
@@ -14,7 +10,7 @@ import           Logic.ImplicationGraph.Induction
 
 -- | Repeatedly unwind the program until a counterexample is found or inductive
 -- invariants are found.
-solve :: MonadIO m => Integer -> ImplGr Integer -> m (Either Model (ImplGr Idx))
+solve :: (IntoIdx i, MonadIO m) => i -> ImplGr i -> m (Either Model (ImplGr Idx))
 solve = loop safetyStrat
 
 safetyStrat :: Strategy Edge


### PR DESCRIPTION
Parse Java source to detect query nodes, parse it into Haskell as well.

Also:
1. Auto find query vertex in `solve`
2. Auto find entry vertex in `solve`
3. `solve` now works on graphs with any index that implements `ToIdx`
4. Detect boolean temp vars and map their assignments from ints to bools
5. Parse `Wunderhorn.ensure()` into a query node to use in Haskell.

With this we have a full Java -> Safe process:
```java
public class EvenLoop {
    public static void loop(int n) {
        int i = 0;
        while (i < n) {
            i = i + 2;
        }
        Wunderhorn.ensure(i != 41);
    }
}
```

Which when parsed and fed into the verifier correctly determines that this is safe: [unfolded.pdf](https://github.com/DAHeath/Logic/files/1462444/solved.dot.pdf)
